### PR TITLE
use socket.io 1.3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   , "dependencies": {
       "express": "3.0.0rc2"
     , "jade": "0.27.2"
-    , "socket.io": "0.9.12"
+    , "socket.io": "1.3.5"
     , "mongoose": "3.8.24"
     , "redis" : "0.7.2"
     , "stylus" : "0.28.2"

--- a/server.js
+++ b/server.js
@@ -52,12 +52,6 @@ app.configure(function() {
 
 const server = require('http').createServer(app);
 const io = require('socket.io').listen(server);
-io.configure('production', function(){
-    io.enable('browser client etag');
-    io.enable('browser client minification');
-    io.enable('browser client gzip');
-    io.set('log level', 1);
-});
 
 if(app.settings.env == 'development') {
     var listen = server.listen(3001);


### PR DESCRIPTION
configure is gone. use `DEBUG='socket.io:*' node server.js` to debug log
refs #4 
